### PR TITLE
Fix documentation typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ npm i scaffolder -g
 #### Create jest test file template
 ```js
 //cli
-scaffolder jester myfileName myFuncName myExpectedSuccessResult myExpectedErrorResult 
+scaffolder jester myfileName myFunc myExpectedSuccessResult myExpectedErrorResult 
 ```
 ```js
 //myFileName.test.js


### PR DESCRIPTION
It should either be myFuncName or myFunc. Changing to myFunc is cheaper.